### PR TITLE
Separate icon config and text in lualine component

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ To show the current venv in for example a status-line you can call
 require('swenv.api').get_current_venv()
 ```
 
-For `lualine` there is already a configured component called `swenv`.
-
 ## Configuration
 Pass a dictionary into `require("swenv").setup()` with callback functions.
 These are the defaults:
@@ -39,4 +37,27 @@ require('swenv').setup({
   -- Something to do after setting an environment, for example call vim.cmd.LspRestart
   post_set_venv = nil,
 })
+```
+
+### Lualine Component
+For `lualine` there is already a configured component called `swenv`.
+It displays an icon and the name of the activated environment.
+
+#### Usage
+Add this to your ```lualine``` sections to use the component
+```lua
+sections = {
+    ...
+    lualine_a = 'swenv' -- uses default options
+    lualine_x = { 'swenv', icon = '<icon>' } -- passing lualine component options
+    ...
+}
+```
+
+These are the defaults options:
+```lua
+{
+  icon = "",
+  color = { fg = "#8fb55e" },
+}
 ```

--- a/lua/lualine/components/swenv.lua
+++ b/lua/lualine/components/swenv.lua
@@ -1,22 +1,19 @@
 local M = require('lualine.component'):extend()
 
-local highlight = require('lualine.highlight')
-local utils = require('lualine.utils.utils')
+local default_opts = {
+  icon = "",
+  color = { fg = "#8fb55e" },
+}
 
 function M:init(options)
+  options = vim.tbl_deep_extend("keep", options or {}, default_opts)
   M.super.init(self, options)
-  self.colors = {}
-  self.color = highlight.create_component_highlight_group(
-    {fg = utils.extract_highlight_colors('WarningMsg', 'fg')},
-    'swenv',
-    self.options
-  )
 end
 
 function M:update_status()
   local venv = require('swenv.api').get_current_venv()
   if venv then
-    return string.format('%s %s', highlight.component_format_highlight(self.color), venv.name)
+    return venv.name
   else
     return ''
   end

--- a/lua/lualine/components/swenv.lua
+++ b/lua/lualine/components/swenv.lua
@@ -2,7 +2,7 @@ local M = require('lualine.component'):extend()
 
 local default_opts = {
   icon = "",
-  color = { fg = "#8fb55e" },
+  color = { fg = "#FFD43B" },
 }
 
 function M:init(options)


### PR DESCRIPTION
Separates the icon config and text in the lualine component allowing configuration of the default icon.