### PR TITLE
add ignore_envs_groups parametr

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you havent some envs group, you can disable they, to save startup time:
 
 ```lua
 require('swenv').setup({
-  ignore_envs_groups = {'conda', 'pixi', 'micromamba', 'pyenv'}
+  ignore_envs = {'conda', 'pixi', 'micromamba', 'pyenv'}
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ require('swenv.api').pick_venv()
 to pick an environment. Uses `vim.ui.select` so a tip is to use eg
 [dressing.nvim](https://github.com/stevearc/dressing.nvim).
 
+### Supported envs
+
+Swenv supports various env types:
+Conda, pixi, micromamba, pyenv... For some envs types, such as poetry, you can specify env path: 
+
+```lua
+require('swenv').setup({
+  venvs_path = vim.fn.expand('~/.cache/pypoetry/virtualenvs'),
+})
+```
+
+If you havent some envs group, you can disable they, to save startup time:
+
+```lua
+require('swenv').setup({
+  ignore_envs_groups = {'conda', 'pixi', 'micromamba', 'pyenv'}
+})
+```
+
+
 ### Get Environment
 
 To show the current venv in for example a status-line you can call

--- a/doc/swenv.txt
+++ b/doc/swenv.txt
@@ -56,7 +56,7 @@ If you havent some envs group, you can disable they, to save startup time:
 
 >lua
     require('swenv').setup({
-      ignore_envs_groups = {'conda', 'pixi', 'micromamba', 'pyenv'}
+      ignore_envs = {'conda', 'pixi', 'micromamba', 'pyenv'}
     })
 <
 

--- a/doc/swenv.txt
+++ b/doc/swenv.txt
@@ -41,6 +41,26 @@ to pick an environment. Uses `vim.ui.select` so a tip is to use eg
 dressing.nvim <https://github.com/stevearc/dressing.nvim>.
 
 
+SUPPORTED ENVS ~
+
+Swenv supports various env types: Conda, pixi, micromamba, pyenv… For some
+envs types, such as poetry, you can specify env path:
+
+>lua
+    require('swenv').setup({
+      venvs_path = vim.fn.expand('~/.cache/pypoetry/virtualenvs'),
+    })
+<
+
+If you havent some envs group, you can disable they, to save startup time:
+
+>lua
+    require('swenv').setup({
+      ignore_envs_groups = {'conda', 'pixi', 'micromamba', 'pyenv'}
+    })
+<
+
+
 GET ENVIRONMENT ~
 
 To show the current venv in for example a status-line you can call

--- a/lua/swenv/config.lua
+++ b/lua/swenv/config.lua
@@ -10,6 +10,7 @@ M.settings = {
   -- Path passed to `get_venvs`.
   venvs_path = vim.fn.expand('~/venvs'),
   -- Something to do after setting an environment
+  ignore_envs_groups = {},
   post_set_venv = nil,
 }
 

--- a/lua/swenv/config.lua
+++ b/lua/swenv/config.lua
@@ -10,7 +10,7 @@ M.settings = {
   -- Path passed to `get_venvs`.
   venvs_path = vim.fn.expand('~/venvs'),
   -- Something to do after setting an environment
-  ignore_envs_groups = {},
+  ignore_envs = {},
   post_set_venv = nil,
 }
 

--- a/lua/swenv/match.lua
+++ b/lua/swenv/match.lua
@@ -21,13 +21,13 @@ end
 
 -- Function to find the best match based on Levenshtein distance
 M.best_match = function(items, query)
-  local min_distance = math.huge -- Initialize minimum distance as infinity
-  local match = nil -- Initialize match as nil to handle case if no match found
-  for _, item in ipairs(items) do -- Iterate over items
+  local min_distance = math.huge           -- Initialize minimum distance as infinity
+  local match = nil                        -- Initialize match as nil to handle case if no match found
+  for _, item in ipairs(items) do          -- Iterate over items
     local distance = lev(query, item.name) -- Compute Levenshtein distance to the query
-    if distance < min_distance then -- If this item is closer to query...
-      min_distance = distance -- Update minimum distance
-      match = item -- Update the match
+    if distance < min_distance then        -- If this item is closer to query...
+      min_distance = distance              -- Update minimum distance
+      match = item                         -- Update the match
     end
   end
   return match -- Return the best match

--- a/lua/swenv/project.lua
+++ b/lua/swenv/project.lua
@@ -6,7 +6,7 @@ M.read_venv_name = function(project_dir)
   if not file then
     return nil
   end
-  local content = file:read('*a') -- *a or *all reads the whole file
+  local content = file:read('*a')      -- *a or *all reads the whole file
   file:close()
   return content:match('^%s*(.-)%s*$') -- Trim whitespace
 end


### PR DESCRIPTION
The author of the plugin noted that the support of many different groups of virtual environments can negatively affect the performance of the plugin. In this regard, I added the "ignore_envs_groups" parameter. this is a table that should contain rows with the names of virtual environment groups. By default, the table is empty so as not to break the backward compatibility of the plugin. But anyone can add to this variable all the groups of environments that they do not use, thereby saving the plugin time.