### PR TITLE
feat: auto_venv support for in-project venvs, created with pyenv

### DIFF
--- a/lua/swenv/api.lua
+++ b/lua/swenv/api.lua
@@ -3,7 +3,8 @@ local M = {}
 local Path = require('plenary.path')
 local scan_dir = require('plenary.scandir').scan_dir
 local best_match = require('swenv.match').best_match
-local read_venv_name = require('swenv.project').read_venv_name
+local read_venv_name_in_project = require('swenv.project').read_venv_name_in_project
+local read_venv_name_common_dir = require('swenv.project').read_venv_name_common_dir
 local get_local_venv_path = require('swenv.project').get_local_venv_path
 
 local settings = require('swenv.config').settings
@@ -196,19 +197,19 @@ M.auto_venv = function()
 
   local project_dir, _ = project_nvim.get_project_root()
   if project_dir then -- project_nvim.get_project_root might not always return a project path
-    local project_venv_name = read_venv_name(project_dir)
-    if not project_venv_name then
+    local venv_name = read_venv_name_in_project(project_dir)
+    if venv_name then
+      local venv = { path = get_local_venv_path(project_dir), name = venv_name }
+      set_venv(venv)
       return
     end
-    -- in-project venv activation
-    local venv = { path = get_local_venv_path(project_dir), name = project_venv_name }
-
-    -- venvs folder actication
-    if not venv.path then
-      venv = best_match(venvs, project_venv_name)
-    end
-    if venv then
-      set_venv(venv)
+    venv_name = read_venv_name_common_dir(project_dir)
+    if venv_name then
+      local venv = best_match(venvs, venv_name)
+      if venv then
+        set_venv(venv)
+        return
+      end
     end
   end
 end

--- a/lua/swenv/project.lua
+++ b/lua/swenv/project.lua
@@ -1,39 +1,45 @@
 local M = {}
 
 M.get_local_venv_path = function(project_dir)
-  local abs_venv_path = project_dir .. '/.venv'
-  return abs_venv_path
+  return project_dir .. '/.venv'
 end
 
 -- Get the name from a `.venv` file in the project root directory.
-M.read_venv_name = function(project_dir)
+M.read_venv_name_in_project = function(project_dir)
+  -- local in-project pyenv environment
   local abs_venv_path = M.get_local_venv_path(project_dir)
   local venv_file = io.open(abs_venv_path, 'r') -- r read mode
   if not venv_file then
     return nil
   end
 
-  -- local in-project pyenv environment
-  local env_name = nil
   local pyenv_cfg = io.open(abs_venv_path .. '/pyvenv.cfg')
-  if pyenv_cfg then
-    for line in pyenv_cfg:lines() do
-      local match = line:match('^prompt%s*=%s*(.*)')
-      if match then
-        env_name = match
-      end
+  if not pyenv_cfg then
+    return nil
+  end
+  for line in pyenv_cfg:lines() do
+    local match = line:match('^prompt%s*=%s*(.*)')
+    if match then
+      local env_name = match
+      pyenv_cfg:close()
+      return env_name
     end
-    pyenv_cfg:close()
+  end
+end
+
+M.read_venv_name_common_dir = function(project_dir)
+  -- centralized environment
+  local abs_venv_path = M.get_local_venv_path(project_dir)
+  local venv_file = io.open(abs_venv_path, 'r') -- r read mode
+  if not venv_file then
+    return nil
   end
 
-  -- centralized environment
-  if not env_name then
-    local content = venv_file:read('*a') -- *a or *all reads the whole file
-    if content == nil then
-      return nil
-    end
-    env_name = content:match('^%s*(.-)%s*$') -- Trim whitespace
+  local content = venv_file:read('*a') -- *a or *all reads the whole file
+  if not content then
+    return nil
   end
+  local env_name = content:match('^%s*(.-)%s*$') -- Trim whitespace
 
   venv_file:close()
   return env_name

--- a/lua/swenv/project.lua
+++ b/lua/swenv/project.lua
@@ -1,17 +1,42 @@
 local M = {}
 
+M.get_local_venv_path = function(project_dir)
+  local abs_venv_path = project_dir .. '/.venv'
+  return abs_venv_path
+end
+
 -- Get the name from a `.venv` file in the project root directory.
 M.read_venv_name = function(project_dir)
-  local file = io.open(project_dir .. '/.venv', 'r') -- r read mode
-  if not file then
+  local abs_venv_path = M.get_local_venv_path(project_dir)
+  local venv_file = io.open(abs_venv_path, 'r') -- r read mode
+  if not venv_file then
     return nil
   end
-  local content = file:read('*a') -- *a or *all reads the whole file
-  if content == nil then
-    return nil
+
+  -- local in-project pyenv environment
+  local env_name = nil
+  local pyenv_cfg = io.open(abs_venv_path .. '/pyvenv.cfg')
+  if pyenv_cfg then
+    for line in pyenv_cfg:lines() do
+      local match = line:match('^prompt%s*=%s*(.*)')
+      if match then
+        env_name = match
+      end
+    end
+    pyenv_cfg:close()
   end
-  file:close()
-  return content:match('^%s*(.-)%s*$') -- Trim whitespace
+
+  -- centralized environment
+  if not env_name then
+    local content = venv_file:read('*a') -- *a or *all reads the whole file
+    if content == nil then
+      return nil
+    end
+    env_name = content:match('^%s*(.-)%s*$') -- Trim whitespace
+  end
+
+  venv_file:close()
+  return env_name
 end
 
 return M


### PR DESCRIPTION
I had some trouble activating venvs which are defined in-project (e.g. /Users/User/project/.venv) and realized that this is not supported. The virtual environment has to be created with pyenv, so that the plugin can parse the venv-name out of the `pyvenv.cfg` file (promt variable).
```
home = /Users/hi-there/.pyenv/versions/3.10.11/bin
implementation = CPython
version_info = 3.10.11.final.0
virtualenv = 20.26.0
include-system-site-packages = false
base-prefix = /Users/hi-there/.pyenv/versions/3.10.11
base-exec-prefix = /Users/hi-there/.pyenv/versions/3.10.11
base-executable = /Users/hi-there/.pyenv/versions/3.10.11/bin/python3.10
prompt = my-package-py3.10
```
If a venv was found in-project, it takes precedence over venvs defined in the "centralized" venvs folder in user directory.

Let me know what you think about the additions. If thats something interesting for anybody I could look for a solution for venvs which were not created with pyenv.