### PR TITLE
feat: Add new feature to auto create a venv directory and set

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For example using [`packer`](https://github.com/wbthomason/packer.nvim):
 ```lua
 use 'AckslD/swenv.nvim'
 ```
+
 Requires `plenary`.
 
 ## Usage
@@ -46,16 +47,44 @@ require('swenv.api').set_venv('venv_fuzzy_name')
 
 ### Auto Environment
 
+```lua
+require('swenv.api').auto_venv()
+```
+
 Using a file named **.venv** in your projects root folder, it will automatically set the
 virtual-env for such environment.
 
-#### Dependency
+#### project.nvim
 
-This requires you to have the [project_nvim](https://github.com/ahmedkhalf/project.nvim)
-package installed.
+With [project_nvim](https://github.com/ahmedkhalf/project.nvim) installed swenv.nvim will activate in-project venvs if present.
+
+This integration is skipped if `auto_create_venv` is enabled
+
+#### Auto Create venv
+
+You can have swenv.nvim attempt to create a venv directory and set to it.
+
+swenv.nvim will search up for a file containing dependencies and create a new venv directory set to `auto_create_venv_dir`
+
+Supported install types in order:
+
+- `pdm sync` with `pdm.lock` (does not modify pdm settings. You need to set the venv directory in pdm)
+
+> These require the `venv` module in python:
+
+- `pip install` with `requirements.txt`
+- `pip install` with `dev-requirements.txt` (preferred over requirements.txt)
+- `pip install` with `pyproject.toml`
 
 ```lua
-require('swenv.api').auto_venv()
+
+require('swenv').setup({
+    -- attempt to auto create and set a venv from dependencies
+    auto_create_venv = true,
+    -- name of venv directory to create if using pip
+    auto_create_venv_dir = ".venv"
+})
+
 ```
 
 #### Auto Command
@@ -95,6 +124,31 @@ require('swenv').setup({
   -- Something to do after setting an environment, for example call vim.cmd.LspRestart
   post_set_venv = nil,
 })
+```
+
+### Reload LSP client on setting venv
+
+You can get your lsp client by name and reload the client after setting the venv.
+
+```lua
+post_set_venv = function()
+  local client = vim.lsp.get_clients({ name = "basedpyright" })[1]
+  if not client then
+    return
+  end
+  local venv = require("swenv.api").get_current_venv()
+  if not venv then
+    return
+  end
+  local venv_python = venv.path .. "/bin/python"
+  if client.settings then
+    client.settings = vim.tbl_deep_extend("force", client.settings, { python = { pythonPath = venv_python } })
+  else
+    client.config.settings =
+        vim.tbl_deep_extend("force", client.config.settings, { python = { pythonPath = venv_python } })
+  end
+  client.notify("workspace/didChangeConfiguration", { settings = nil })
+end,
 ```
 
 ### Lualine Component

--- a/lua/swenv/api.lua
+++ b/lua/swenv/api.lua
@@ -18,7 +18,7 @@ local update_path = function(path)
   vim.fn.setenv('PATH', path .. '/bin' .. ':' .. ORIGINAL_PATH)
 end
 
-local set_venv = function(venv)
+M.set_venv_path = function(venv)
   if venv.source == 'conda' or venv.source == 'micromamba' then
     vim.fn.setenv('CONDA_PREFIX', venv.path)
     vim.fn.setenv('CONDA_DEFAULT_ENV', venv.name)
@@ -173,7 +173,7 @@ M.pick_venv = function()
     if not choice then
       return
     end
-    set_venv(choice)
+    M.set_venv_path(choice)
   end)
 end
 
@@ -183,7 +183,7 @@ M.set_venv = function(name)
   if not closest_match then
     return
   end
-  set_venv(closest_match)
+  M.set_venv_path(closest_match)
 end
 
 ---
@@ -195,14 +195,14 @@ local auto_venv_project_nvim = function(project_nvim, venvs)
     local venv_name = read_venv_name_in_project(project_dir)
     if venv_name then
       local venv = { path = get_local_venv_path(project_dir), name = venv_name }
-      set_venv(venv)
+      M.set_venv_path(venv)
       return
     end
     venv_name = read_venv_name_common_dir(project_dir)
     if venv_name then
       local venv = best_match(venvs, venv_name)
       if venv then
-        set_venv(venv)
+        M.set_venv_path(venv)
         return
       end
     end

--- a/lua/swenv/config.lua
+++ b/lua/swenv/config.lua
@@ -11,6 +11,14 @@ M.settings = {
   venvs_path = vim.fn.expand('~/venvs'),
   -- Something to do after setting an environment
   post_set_venv = nil,
+  -- Attempt detect and auto create venv directories using
+  -- pdm
+  -- requirements.txt
+  -- dev-requirements.txt
+  -- pyproject.toml
+  auto_create_venv = false,
+  -- directory to create for venv auto creation
+  auto_create_venv_dir = '.venv',
 }
 
 return M

--- a/lua/swenv/create.lua
+++ b/lua/swenv/create.lua
@@ -96,7 +96,7 @@ local function pip_install_with_venv(requirements_path)
         else
           local pip_path = venv_path .. '/' .. 'bin/pip'
           local install_args = { 'install', '-r', requirements_path }
-          if requirements_path == 'pyproject.toml' then
+          if string.find(requirements_path, 'pyproject.toml$') then
             install_args = { 'install', '.' }
           end
           Job:new({
@@ -108,7 +108,6 @@ local function pip_install_with_venv(requirements_path)
                 if k.code ~= 0 then
                   vim.notify('swenv.nvim: ' .. vim.inspect(k._stderr_results), vim.log.levels.ERROR)
                 else
-
                   local venv_name = vim.fs.basename(dir_name)
                   swenv_set_venv(venv_path, venv_name)
                   vim.notify('Set venv: ' .. venv_path, vim.log.levels.INFO)
@@ -123,7 +122,7 @@ local function pip_install_with_venv(requirements_path)
 end
 
 --- Automatically create venv directory and use multiple method to auto install dependencies
---- Use module level variable Auto_set_python_venv_parent_dir to keep track of the last venv dir, so 
+--- Use module level variable Auto_set_python_venv_parent_dir to keep track of the last venv dir, so
 ---   We don't do the creation process again when you are in the same project.
 M.auto_create_set_python_venv = function()
   local stop = false

--- a/lua/swenv/create.lua
+++ b/lua/swenv/create.lua
@@ -6,7 +6,8 @@ local venv_dir = settings.auto_create_venv_dir
 --- Set venv via swenv. Only set venv if its different than current.
 --- local venv_dir = settings.auto_create_venv_dir
 ---@param venv_path string full path to venv directory
-local function swenv_set_venv(venv_path)
+---@param venv_name string name of the venv to set
+local function swenv_set_venv(venv_path, venv_name)
   if venv_path then
     local swenv_api = require('swenv.api')
     local current_venv_name = nil
@@ -15,7 +16,7 @@ local function swenv_set_venv(venv_path)
       current_venv_name = current_venv.name
     end
     if venv_path ~= current_venv_name then
-      swenv_api.set_venv(venv_path)
+      swenv_api.set_venv_path({ path = venv_path, name = current_venv_name })
     end
   end
 end
@@ -61,7 +62,8 @@ local function pdm_sync(pdm_lock_path)
           vim.notify('swenv.nvim: ' .. vim.inspect(j._stderr_results), vim.log.levels.ERROR)
         else
           local venv_path = dir_name .. '/' .. venv_dir
-          swenv_set_venv(venv_path)
+          local venv_name = vim.fs.basename(dir_name)
+          swenv_set_venv(venv_path, venv_name)
           vim.notify('swenv.nvim: set venv: ' .. venv_path, vim.log.levels.INFO)
         end
       end)
@@ -106,7 +108,9 @@ local function pip_install_with_venv(requirements_path)
                 if k.code ~= 0 then
                   vim.notify('swenv.nvim: ' .. vim.inspect(k._stderr_results), vim.log.levels.ERROR)
                 else
-                  swenv_set_venv(venv_path)
+
+                  local venv_name = vim.fs.basename(dir_name)
+                  swenv_set_venv(venv_path, venv_name)
                   vim.notify('Set venv: ' .. venv_path, vim.log.levels.INFO)
                 end
               end)
@@ -126,7 +130,8 @@ M.auto_create_set_python_venv = function()
       path = venv_dir,
       callback = function(path)
         -- initial set, still want to do dependency install from others if available
-        swenv_set_venv(path)
+        local venv_name = vim.fs.basename(vim.fs.dirname(path))
+        swenv_set_venv(path, venv_name)
       end,
     },
     {

--- a/lua/swenv/create.lua
+++ b/lua/swenv/create.lua
@@ -123,6 +123,8 @@ local function pip_install_with_venv(requirements_path)
 end
 
 --- Automatically create venv directory and use multiple method to auto install dependencies
+--- Use module level variable Auto_set_python_venv_parent_dir to keep track of the last venv dir, so 
+---   We don't do the creation process again when you are in the same project.
 M.auto_create_set_python_venv = function()
   local stop = false
   local check_paths = {
@@ -138,7 +140,7 @@ M.auto_create_set_python_venv = function()
       path = 'pdm.lock',
       callback = function(path)
         pdm_sync(path)
-        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        Auto_set_python_venv_parent_dir = vim.fs.dirname(path)
         stop = true
       end,
     },
@@ -146,7 +148,7 @@ M.auto_create_set_python_venv = function()
       path = 'requirements.txt',
       callback = function(path)
         pip_install_with_venv(path)
-        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        Auto_set_python_venv_parent_dir = vim.fs.dirname(path)
         stop = true
       end,
     },
@@ -154,7 +156,7 @@ M.auto_create_set_python_venv = function()
       path = 'dev-requirements.txt',
       callback = function(path)
         pip_install_with_venv(path)
-        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        Auto_set_python_venv_parent_dir = vim.fs.dirname(path)
         stop = true
       end,
     },
@@ -162,7 +164,7 @@ M.auto_create_set_python_venv = function()
       path = 'pyproject.toml',
       callback = function(path)
         pip_install_with_venv(path)
-        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        Auto_set_python_venv_parent_dir = vim.fs.dirname(path)
         stop = true
       end,
     },
@@ -177,7 +179,7 @@ M.auto_create_set_python_venv = function()
     end
     found_path = search_up(search_path)
     if found_path ~= nil then
-      local last_parent_dir = vim.g._auto_set_python_venv_parent_dir
+      local last_parent_dir = Auto_set_python_venv_parent_dir
       local new_parent_dir = vim.fs.dirname(found_path)
       if last_parent_dir ~= new_parent_dir then
         callback(found_path)

--- a/lua/swenv/create.lua
+++ b/lua/swenv/create.lua
@@ -1,0 +1,184 @@
+local M = {}
+
+local settings = require('swenv.config').settings
+local venv_dir = settings.auto_create_venv_dir
+
+--- Set venv via swenv. Only set venv if its different than current.
+--- local venv_dir = settings.auto_create_venv_dir
+---@param venv_path string full path to venv directory
+local function swenv_set_venv(venv_path)
+  if venv_path then
+    local swenv_api = require('swenv.api')
+    local current_venv_name = nil
+    local current_venv = swenv_api.get_current_venv()
+    if current_venv then
+      current_venv_name = current_venv.name
+    end
+    if venv_path ~= current_venv_name then
+      swenv_api.set_venv(venv_path)
+    end
+  end
+end
+
+--- Search for file or directory until we either the top of the git repo or root
+---@param dir_or_file string name of directory or file
+---@return string | nil found either nil or full path of found file/directory
+local function search_up(dir_or_file)
+  local found = nil
+  local dir_to_check = nil
+  -- get parent directory via vim expand
+  local dir_template = '%:p:h'
+  while not found and dir_to_check ~= '/' do
+    dir_to_check = vim.fn.expand(dir_template)
+    local check_path = dir_to_check .. '/' .. dir_or_file
+    local check_git = dir_to_check .. '/' .. '.git'
+    if vim.fn.isdirectory(check_path) == 1 or vim.fn.filereadable(check_path) == 1 then
+      found = dir_to_check .. '/' .. dir_or_file
+    else
+      dir_template = dir_template .. ':h'
+    end
+    -- If we hit a .git directory then stop searching and return found even if nil
+    if vim.fn.isdirectory(check_git) == 1 then
+      return found
+    end
+  end
+  return found
+end
+
+--- Run pdm sync at lock file directory. Set swvenv env path when done.
+---@param pdm_lock_path string full path to pdm lock file
+local function pdm_sync(pdm_lock_path)
+  local Job = require('plenary.job')
+  vim.notify('swenv.nvim: starting pdm sync at: ' .. pdm_lock_path, vim.log.levels.INFO)
+  local dir_name = vim.fs.dirname(pdm_lock_path)
+  Job:new({
+    command = 'pdm',
+    args = { 'sync' },
+    cwd = dir_name,
+    on_exit = function(j, _)
+      vim.schedule(function()
+        if j.code ~= 0 then
+          vim.notify('swenv.nvim: ' .. vim.inspect(j._stderr_results), vim.log.levels.ERROR)
+        else
+          local venv_path = dir_name .. '/' .. venv_dir
+          swenv_set_venv(venv_path)
+          vim.notify('swenv.nvim: set venv: ' .. venv_path, vim.log.levels.INFO)
+        end
+      end)
+    end,
+  }):start()
+end
+
+--- Create venv with python venv module and pip install at location
+---@param requirements_path string full path to requirements.txt, dev-requirements.txt or pyproject.toml
+local function pip_install_with_venv(requirements_path)
+  local Job = require('plenary.job')
+  local dir_name = vim.fs.dirname(requirements_path)
+  local venv_path = dir_name .. '/' .. venv_dir
+  vim.notify(
+    'swenv.nvim: starting pip install at: ' .. requirements_path .. ' in venv: ' .. venv_path,
+    vim.log.levels.INFO
+  )
+  local python_app = 'python3'
+  if vim.fn.executable(python_app) ~= 1 then
+    python_app = 'python'
+  end
+  Job:new({
+    command = python_app,
+    args = { '-m', 'venv', venv_path },
+    cwd = dir_name,
+    on_exit = function(j, _)
+      vim.schedule(function()
+        if j.code ~= 0 then
+          vim.notify('swenv.nvim: ' .. vim.inspect(j._stderr_results .. j._stdout_results), vim.log.levels.ERROR)
+        else
+          local pip_path = venv_path .. '/' .. 'bin/pip'
+          local install_args = { 'install', '-r', requirements_path }
+          if requirements_path == 'pyproject.toml' then
+            install_args = { 'install', '.' }
+          end
+          Job:new({
+            command = pip_path,
+            args = install_args,
+            cwd = dir_name,
+            on_exit = function(k, _)
+              vim.schedule(function()
+                if k.code ~= 0 then
+                  vim.notify('swenv.nvim: ' .. vim.inspect(k._stderr_results), vim.log.levels.ERROR)
+                else
+                  swenv_set_venv(venv_path)
+                  vim.notify('Set venv: ' .. venv_path, vim.log.levels.INFO)
+                end
+              end)
+            end,
+          }):start()
+        end
+      end)
+    end,
+  }):start()
+end
+
+--- Automatically create venv directory and use multiple method to auto install dependencies
+M.auto_create_set_python_venv = function()
+  local stop = false
+  local check_paths = {
+    {
+      path = venv_dir,
+      callback = function(path)
+        -- initial set, still want to do dependency install from others if available
+        swenv_set_venv(path)
+      end,
+    },
+    {
+      path = 'pdm.lock',
+      callback = function(path)
+        pdm_sync(path)
+        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        stop = true
+      end,
+    },
+    {
+      path = 'requirements.txt',
+      callback = function(path)
+        pip_install_with_venv(path)
+        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        stop = true
+      end,
+    },
+    {
+      path = 'dev-requirements.txt',
+      callback = function(path)
+        pip_install_with_venv(path)
+        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        stop = true
+      end,
+    },
+    {
+      path = 'pyproject.toml',
+      callback = function(path)
+        pip_install_with_venv(path)
+        vim.g._auto_set_python_venv_parent_dir = vim.fs.dirname(path)
+        stop = true
+      end,
+    },
+  }
+
+  for _, val in ipairs(check_paths) do
+    local found_path = nil
+    local search_path = val['path']
+    local callback = val['callback']
+    if stop then
+      return
+    end
+    found_path = search_up(search_path)
+    if found_path ~= nil then
+      local last_parent_dir = vim.g._auto_set_python_venv_parent_dir
+      local new_parent_dir = vim.fs.dirname(found_path)
+      if last_parent_dir ~= new_parent_dir then
+        callback(found_path)
+      end
+    end
+  end
+end
+
+return M

--- a/lua/swenv/create.lua
+++ b/lua/swenv/create.lua
@@ -16,7 +16,7 @@ local function swenv_set_venv(venv_path, venv_name)
       current_venv_name = current_venv.name
     end
     if venv_path ~= current_venv_name then
-      swenv_api.set_venv_path({ path = venv_path, name = current_venv_name })
+      swenv_api.set_venv_path({ path = venv_path, name = venv_name })
     end
   end
 end

--- a/lua/swenv/create.lua
+++ b/lua/swenv/create.lua
@@ -171,8 +171,8 @@ M.auto_create_set_python_venv = function()
 
   for _, val in ipairs(check_paths) do
     local found_path = nil
-    local search_path = val['path']
-    local callback = val['callback']
+    local search_path = val.path
+    local callback = val.callback
     if stop then
       return
     end


### PR DESCRIPTION
- feat(venv): new feature auto_create_venv uses either pdm or pip to attempt to find a dependency file and create a venv directory automatically.

- docs(post_set_venv): Add snippet for reloading an lsp client on post_set_venv

- docs(auto_venv): Adjust auto_venv section to be about auto_create_venv

![image](https://github.com/user-attachments/assets/090523f2-5070-4ed4-bebe-a014f5352c41)
