### PR TITLE
fix: pass filename to get_venvs_for

### DIFF
--- a/lua/swenv/api.lua
+++ b/lua/swenv/api.lua
@@ -98,6 +98,11 @@ local get_venvs_for = function(base_path, source, opts)
   if base_path == nil then
     return venvs
   end
+
+  if Path.is_path(base_path) then
+    base_path = base_path.filename
+  end
+
   local paths = scan_dir(base_path, vim.tbl_extend('force', { depth = 1, only_dirs = true, silent = true }, opts or {}))
   for _, path in ipairs(paths) do
     table.insert(venvs, {


### PR DESCRIPTION
Passing a non-string value causes exceptions to be raised on nvim 0.11.0.

Related:
https://github.com/AckslD/swenv.nvim/issues/52